### PR TITLE
build: create a package.json file to publish on the NPM registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "type": "git",
     "url": "git+https://github.com/SmarDex-Ecosystem/solidity-libs.git"
   },
+  "scripts": {
+    "build": "cargo build --release",
+    "quicktest": "npm run build && forge test --no-match-contract Fuzzing",
+    "test": "npm run build && forge test"
+  },
   "keywords": [
     "Solidity",
     "Blockchain",


### PR DESCRIPTION
This PR aims to allow the publication of the repository as an NPM package by adding a package.json file.
The version in the file is `0.1.0` for now, we will put the real version when we do the first release with the chosen versioning type.

Closes RA2BL-383